### PR TITLE
phosphor buttons: Enable Delayed/Fast Power Off

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -66,7 +66,7 @@ add_executable(${PROJECT_NAME} ${SRC_FILES} )
 target_link_libraries(${PROJECT_NAME} "${SDBUSPLUSPLUS_LIBRARIES} -lphosphor_dbus  -lstdc++fs")
 
 add_executable(button-handler ${HANDLER_SRC_FILES})
-target_link_libraries(button-handler "${SDBUSPLUSPLUS_LIBRARIES} -lphosphor_dbus")
+target_link_libraries(button-handler "${SDBUSPLUSPLUS_LIBRARIES} -lfmt -lsdeventplus -lphosphor_dbus")
 
 set (
     SERVICE_FILES

--- a/inc/button_interface.hpp
+++ b/inc/button_interface.hpp
@@ -50,8 +50,9 @@ class ButtonIface
 
             ButtonIface* buttonIface = static_cast<ButtonIface*>(userdata);
             buttonIface->handleEvent(es, fd, revents);
-            return 0;
         }
+
+        return 0;
     }
 
     std::string getFormFactorType() const

--- a/src/button_handler_main.cpp
+++ b/src/button_handler_main.cpp
@@ -1,15 +1,41 @@
 #include "button_handler.hpp"
+#include "common.hpp"
+
+#include <phosphor-logging/log.hpp>
 
 int main(int argc, char* argv[])
 {
     auto bus = sdbusplus::bus::new_default();
 
-    phosphor::button::Handler handler{bus};
-
-    while (true)
+    int ret = 0;
+    sd_event* event = nullptr;
+    ret = sd_event_default(&event);
+    if (ret < 0)
     {
-        bus.process_discard();
-        bus.wait();
+        phosphor::logging::log<phosphor::logging::level::ERR>(
+            "Error creating a default sd_event handler");
+        return ret;
     }
-    return 0;
+    EventPtr eventP{event};
+    event = nullptr;
+
+    try
+    {
+        bus.attach_event(eventP.get(), SD_EVENT_PRIORITY_NORMAL);
+        phosphor::button::Handler handler{bus};
+
+        ret = sd_event_loop(eventP.get());
+        if (ret < 0)
+        {
+            phosphor::logging::log<phosphor::logging::level::ERR>(
+                "Error occurred during the sd_event_loop",
+                phosphor::logging::entry("RET=%d", ret));
+        }
+    }
+    catch (const std::exception& e)
+    {
+        phosphor::logging::log<phosphor::logging::level::ERR>(e.what());
+        ret = -1;
+    }
+    return ret;
 }

--- a/src/power_button.cpp
+++ b/src/power_button.cpp
@@ -26,7 +26,7 @@ void PowerButton::simPress()
 
 void PowerButton::simLongPress()
 {
-    pressedLong();
+    released();
 }
 
 void PowerButton::updatePressedTime()
@@ -67,7 +67,6 @@ void PowerButton::handleEvent(sd_event_source* es, int fd, uint32_t revents)
         phosphor::logging::log<phosphor::logging::level::DEBUG>(
             "POWER_BUTTON: pressed");
 
-        updatePressedTime();
         // emit pressed signal
         pressed();
     }
@@ -76,18 +75,7 @@ void PowerButton::handleEvent(sd_event_source* es, int fd, uint32_t revents)
         phosphor::logging::log<phosphor::logging::level::DEBUG>(
             "POWER_BUTTON: released");
 
-        auto now = std::chrono::steady_clock::now();
-        auto d = std::chrono::duration_cast<std::chrono::milliseconds>(
-            now - getPressTime());
-
-        if (d > std::chrono::milliseconds(LONG_PRESS_TIME_MS))
-        {
-            pressedLong();
-        }
-        else
-        {
-            // released
-            released();
-        }
+        // emit released signal
+        released();
     }
 }


### PR DESCRIPTION
The current Power Button behavior is to power On or Off host with a
short press. The power Off behaviour on FSP-based platforms is
different, and is follows:
Initial 4 seconds: do nothing
Delayed Power Off Initiated: With this, 10 seconds countdown begins.
If Button is released during this interval and not pressed again,
normal shutdown - equivalent to 'obmcutil poweroff' - starts and
the host goes to Off state. If the Button is released and pressed
again during this interval OR button is held down beyond this interval,
Fast Power Off is initiated with 10 seconds countdown, and the host is
shutdown - equivalent of 'obmcutil chassisoff'.
This commit changes the behavior on p10bmc platforms similar to
FSP-based platforms.

The following tests were performed using simulator signals and
power button on rainier system:
1. Power On host (push/release button)
   Verified: host in 'Running' state
2. Power Off (Release Button within 4s)
   Verified: No change
3. Power Off (Release Button somewhere between 5-9s)
   Verified: host in 'Off' state
4. Power Off (Release Button after 6s, and press/release again)
   Verified: host in 'Off' state
5. Power Off (Release Button after 6s, press and hold it down 15s)
   Verified: host in 'Off' state
6. Power Off (Release after 30s)
   Verified: host in 'Off' state

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>
Change-Id: Ie52d1fd598971776c085e7ba9ce9e5264bd9d508