### PR TITLE
Block host IPLing when BMC is not ready

### DIFF
--- a/inc/button_handler.hpp
+++ b/inc/button_handler.hpp
@@ -94,6 +94,13 @@ class Handler
     bool poweredOn() const;
 
     /**
+     * @brief Checks if BMC is in a Ready state
+     *
+     * @return true if BMC is in ready state, false else
+     */
+    bool isBmcReady() const;
+
+    /**
      * @brief Returns the service name for an object
      *
      * @param[in] path - the object path


### PR DESCRIPTION
When a power button is pressed and released, an attempt is made
to power On/Off the host. The expected behavior is to power operation
to succeed when the BMC is in a Ready state. If the BMC is not ready
at the time power button is pressed then IPLing may result into
unexpected behavior. This change blocks/ignores button press when
BMC is not ready.

Testing (steps used to verify):
- Keep BMC in a 'NotReady' state
/xyz/openbmc_project/state/bmc0 xyz.openbmc_project.State.BMC \
CurrentBMCState s xyz.openbmc_project.State.BMC.BMCState.NotReady

- Use simPress/simLongPress signals to simulate button press/release
/xyz/openbmc_project/Chassis/Buttons/Power0 \
xyz.openbmc_project.Chassis.Buttons.Power simPress; \
sleep 6; \
busctl call xyz.openbmc_project.Chassis.Buttons \
/xyz/openbmc_project/Chassis/Buttons/Power0 \
xyz.openbmc_project.Chassis.Buttons.Power simLongPress

- Check journal log for error
Jun 15 20:24:23 ever6bmc button-handler[8477]: powerBtnPressed: BMC is
not yet ready, try later

Signed-off-by: Shantappa Teekappanavar <sbteeks@yahoo.com>